### PR TITLE
Add net462 and netstandard2.0 targets

### DIFF
--- a/src/DNSKEYRecord.cs
+++ b/src/DNSKEYRecord.cs
@@ -55,7 +55,7 @@ namespace Makaretu.Dns
             }
         }
 
-#if (!NETSTANDARD14 && !NET45)
+#if NET6_0_OR_GREATER
         /// <summary>
         ///   Creates a new instance of the <see cref="DNSKEYRecord"/> class
         ///   from the specified ECDSA key.

--- a/src/Dns.csproj
+++ b/src/Dns.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net462;netstandard2.0</TargetFrameworks>
     <AssemblyName>Makaretu.Dns</AssemblyName>
     <RootNamespace>Makaretu.Dns</RootNamespace>
     <DebugType>portable</DebugType>

--- a/src/PresentationWriter.cs
+++ b/src/PresentationWriter.cs
@@ -111,7 +111,7 @@ namespace Makaretu.Dns
             if (value == string.Empty)
                 needQuote = true;
             value = value.Replace("\\", "\\\\").Replace("\"", "\\\"");
-            if (value.Contains(' '))
+            if (value.Contains(" "))
                 needQuote = true;
 
             if (needQuote)


### PR DESCRIPTION
This allows this project to be easily used from Standard/Framework projects.

4.6.2 is the baseline currently-supported Framework version: https://learn.microsoft.com/en-us/lifecycle/products/microsoft-net-framework